### PR TITLE
Add daemonize option via Double-fork.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,14 +24,16 @@ Options are below:
      Example: kwsgi hello.py app -p 5000 --reload
 
    Options:
-     -h, --host TEXT             The interface to bind to.
-     -p, --port INTEGER          The port to bind to.
-     --reload / --no-reload      Enable live reloading
-     --interval INTEGER          Interval time to check file changed for
-                                 reloading
-     --validate / --no-validate  Validating your WSGI application complying with
-                                 PEP3333 compliance.
-     --help                      Show this message and exit.
+     -h, --host TEXT               The interface to bind to.
+     -p, --port INTEGER            The port to bind to.
+     --reload / --no-reload        Enable live reloading
+     --daemonize / --no-daemonize  Detaches the server from the controlling
+                                   terminal and enters the background.
+     --interval INTEGER            Interval time to check file changed for
+                                   reloading
+     --validate / --no-validate    Validating your WSGI application complying with
+                                   PEP3333 compliance.
+     --help                        Show this message and exit.
 
 
 And you can integrate with kwsgi from python script:

--- a/kwsgi/daemonize.py
+++ b/kwsgi/daemonize.py
@@ -1,0 +1,38 @@
+import os
+import sys
+
+
+DEVNULL = getattr(os, 'devnull', '/dev/null')
+
+
+def daemonize():
+    """Detaches the server from the controlling terminal and enters the background."""
+    if 'KWSGI_CHILD' in os.environ:
+        return
+
+    if os.fork():
+        # Exit a parent process because setsid() will be fail
+        # if you're a process group leader.
+        sys.exit(0)
+
+    # Detaches the process from the controlling terminal.
+    os.setsid()
+
+    if os.fork():
+        sys.exit(0)
+
+    # Continue to run application if directory is removed.
+    os.chdir('/')
+
+    # 0o22 means 755 (777-755)
+    os.umask(0o22)
+
+    # Remap all of stdin, stdout and stderr on to /dev/null.
+    # Please caution that this way couldn't support following execution:
+    #   $ kwsgi ... > output.log 2>&1
+    os.closerange(0, 3)
+    fd_null = os.open(DEVNULL, os.O_RDWR)
+    if fd_null != 0:
+        os.dup2(fd_null, 0)
+    os.dup2(fd_null, 1)
+    os.dup2(fd_null, 2)


### PR DESCRIPTION
Close #1.

References:

* https://www.svbug.com/documentation/comp.unix.programmer-FAQ/faq_2.html#SEC16
* https://github.com/benoitc/gunicorn/blob/91974f0f44080fdd6f2885832d101474671c4b9b/gunicorn/util.py#L417-L497
* https://tell-k.github.io/pyconjp2018/#60 (japanese)

Test:

```
$ ps aux | grep [k]wsgi
$ kwsgi hello_app.py application --daemonize
$ ps aux | grep [k]wsgi
a14737           38785   0.0  0.0  2448880   7568   ??  S    12:18AM   0:00.01 /Users/a14737/PycharmProjects/kwsgi/venv/bin/python /Users/a14737/PycharmProjects/kwsgi/venv/bin/kwsgi hello_app.py application --daemonize
$ kill 38785
$ ps aux | grep [k]wsgi
$
```